### PR TITLE
feat: Implement trigger API endpoints (ENG-30)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,33 @@
+[run]
+source = src
+branch = True
+omit = 
+    */tests/*
+    */__pycache__/*
+    */migrations/*
+    */alembic/*
+    */scripts/*
+    */__init__.py
+
+[report]
+precision = 2
+show_missing = True
+skip_covered = False
+skip_empty = True
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    def __str__
+    raise AssertionError
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:
+    if typing.TYPE_CHECKING:
+    @abstractmethod
+    @abc.abstractmethod
+
+[html]
+directory = htmlcov
+
+[xml]
+output = coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,113 @@
+# Makefile for Blip0 API Project
+
+.PHONY: help
+help: ## Show this help message
+	@echo 'Usage: make [target]'
+	@echo ''
+	@echo 'Available targets:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: test
+test: ## Run all tests
+	uv run pytest
+
+.PHONY: test-triggers
+test-triggers: ## Run trigger tests only
+	uv run pytest tests/api/v1/test_triggers.py -v
+
+.PHONY: test-monitors
+test-monitors: ## Run monitor tests only
+	uv run pytest tests/api/v1/test_monitors.py -v
+
+.PHONY: coverage
+coverage: ## Run tests with coverage report
+	uv run pytest --cov=src --cov-report=term-missing --cov-report=html
+
+.PHONY: coverage-triggers
+coverage-triggers: ## Run trigger tests with coverage
+	uv run pytest tests/api/v1/test_triggers.py --cov=src.app.api.v1.triggers --cov-report=term-missing
+
+.PHONY: coverage-monitors
+coverage-monitors: ## Run monitor tests with coverage
+	uv run pytest tests/api/v1/test_monitors.py --cov=src.app.api.v1.monitors --cov-report=term-missing
+
+.PHONY: coverage-html
+coverage-html: ## Generate HTML coverage report
+	uv run pytest --cov=src --cov-report=html
+	@echo "Coverage report generated in htmlcov/index.html"
+
+.PHONY: coverage-report
+coverage-report: ## Show coverage report in terminal
+	uv run coverage report -m
+
+.PHONY: lint
+lint: ## Run ruff linter
+	uv run ruff check src/
+
+.PHONY: lint-fix
+lint-fix: ## Run ruff linter with auto-fix
+	uv run ruff check --fix src/
+
+.PHONY: mypy
+mypy: ## Run mypy type checker
+	uv run mypy src/
+
+.PHONY: format
+format: ## Format code with ruff
+	uv run ruff format src/
+
+.PHONY: check
+check: lint mypy test ## Run all checks (lint, type check, tests)
+
+.PHONY: check-coverage
+check-coverage: lint mypy coverage ## Run all checks with coverage
+
+.PHONY: clean
+clean: ## Clean up generated files
+	rm -rf __pycache__ .pytest_cache htmlcov .coverage coverage.xml
+	find . -type d -name "__pycache__" -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete
+
+.PHONY: install
+install: ## Install dependencies
+	uv pip install -e .
+
+.PHONY: install-dev
+install-dev: ## Install development dependencies
+	uv pip install -e .[dev]
+
+.PHONY: run
+run: ## Run the FastAPI application
+	uv run uvicorn src.app.main:app --reload
+
+.PHONY: docker-up
+docker-up: ## Start Docker services
+	docker compose up -d
+
+.PHONY: docker-down
+docker-down: ## Stop Docker services
+	docker compose down
+
+.PHONY: docker-logs
+docker-logs: ## Show Docker logs
+	docker compose logs -f
+
+.PHONY: db-migrate
+db-migrate: ## Run database migrations
+	uv run alembic upgrade head
+
+.PHONY: db-rollback
+db-rollback: ## Rollback last migration
+	uv run alembic downgrade -1
+
+.PHONY: db-makemigration
+db-makemigration: ## Create a new migration
+	uv run alembic revision --autogenerate
+
+.PHONY: create-superuser
+create-superuser: ## Create first superuser
+	uv run python -m src.scripts.create_first_superuser
+
+.PHONY: create-tier
+create-tier: ## Create first tier
+	uv run python -m src.scripts.create_first_tier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
 dev = [
     "pytest>=7.4.2",
     "pytest-mock>=3.14.0",
+    "pytest-cov>=4.1.0",
+    "coverage[toml]>=7.3.2",
     "faker>=26.0.0",
     "mypy>=1.8.0",
     "types-redis>=4.6.0",
@@ -101,6 +103,13 @@ convention = "numpy"
 filterwarnings = [
     "ignore::PendingDeprecationWarning:starlette.formparsers",
 ]
+addopts = [
+    "--cov=src",
+    "--cov-report=term-missing",
+    "--cov-report=html",
+    "--cov-report=xml",
+    "--cov-branch",
+]
 
 [dependency-groups]
 dev = [
@@ -119,3 +128,39 @@ explicit_package_bases = true
 [[tool.mypy.overrides]]
 module = "src.app.*"
 disallow_untyped_defs = true
+
+[tool.coverage.run]
+source = ["src"]
+branch = true
+omit = [
+    "*/tests/*",
+    "*/__pycache__/*",
+    "*/migrations/*",
+    "*/alembic/*",
+    "*/scripts/*",
+    "*/__init__.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "def __str__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "if typing.TYPE_CHECKING:",
+    "@abstractmethod",
+    "@abc.abstractmethod",
+]
+precision = 2
+show_missing = true
+skip_covered = false
+skip_empty = true
+
+[tool.coverage.html]
+directory = "htmlcov"
+
+[tool.coverage.xml]
+output = "coverage.xml"

--- a/src/app/api/v1/__init__.py
+++ b/src/app/api/v1/__init__.py
@@ -7,6 +7,7 @@ from .posts import router as posts_router
 from .rate_limits import router as rate_limits_router
 from .tasks import router as tasks_router
 from .tiers import router as tiers_router
+from .triggers import router as triggers_router
 from .users import router as users_router
 
 router = APIRouter(prefix="/v1")
@@ -18,3 +19,4 @@ router.include_router(tasks_router)
 router.include_router(tiers_router)
 router.include_router(rate_limits_router)
 router.include_router(monitors_router)
+router.include_router(triggers_router)

--- a/src/app/api/v1/triggers.py
+++ b/src/app/api/v1/triggers.py
@@ -1,0 +1,708 @@
+"""
+Trigger API endpoints for action configurations.
+Implements CRUD operations with type-specific handling for email and webhook triggers.
+"""
+
+import uuid as uuid_pkg
+from typing import Annotated, Any, Optional
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
+from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ...api.dependencies import get_current_user, rate_limiter_dependency
+from ...core.db.database import async_get_db
+from ...core.exceptions.http_exceptions import (
+    BadRequestException,
+    DuplicateValueException,
+    ForbiddenException,
+    NotFoundException,
+)
+from ...core.logger import logging
+from ...schemas.trigger import (
+    EmailTriggerBase,
+    TriggerCreate,
+    TriggerFilter,
+    TriggerPagination,
+    TriggerRead,
+    TriggerSort,
+    TriggerTestRequest,
+    TriggerTestResult,
+    TriggerUpdate,
+    TriggerValidationRequest,
+    TriggerValidationResult,
+    WebhookTriggerBase,
+)
+from ...services.trigger_service import trigger_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/triggers", tags=["triggers"])
+
+# Constants for trigger state updates - only update specific fields
+ENABLE_TRIGGER_UPDATE = TriggerUpdate(active=True, name=None, slug=None)
+DISABLE_TRIGGER_UPDATE = TriggerUpdate(active=False, name=None, slug=None)
+
+
+@router.get("", response_model=TriggerPagination)
+async def list_triggers(
+    _request: Request,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    current_user: Annotated[dict, Depends(get_current_user)],
+    page: int = Query(1, ge=1, description="Page number"),
+    size: int = Query(50, ge=1, le=100, description="Page size"),
+    # Filter parameters
+    name: Optional[str] = Query(None, description="Filter by name (partial match)"),
+    slug: Optional[str] = Query(None, description="Filter by slug (exact match)"),
+    trigger_type: Optional[str] = Query(None, description="Filter by trigger type (email/webhook)"),
+    active: Optional[bool] = Query(None, description="Filter by active status"),
+    validated: Optional[bool] = Query(None, description="Filter by validation status"),
+    # Sort parameters
+    sort_field: str = Query("created_at", description="Field to sort by"),
+    sort_order: str = Query("desc", pattern="^(asc|desc)$", description="Sort order"),
+) -> dict[str, Any]:
+    """
+    List triggers for the current tenant with pagination, filtering, and sorting.
+
+    Returns paginated list of triggers with metadata.
+    """
+    # Check if user has a tenant
+    if not current_user.get("tenant_id"):
+        raise ForbiddenException("User is not associated with any tenant")
+
+    tenant_id = str(current_user["tenant_id"])
+
+    # Build filter object
+    filters = TriggerFilter(
+        tenant_id=uuid_pkg.UUID(tenant_id),
+        name=name,
+        slug=slug,
+        trigger_type=trigger_type,
+        active=active,
+        validated=validated,
+        created_after=None,
+        created_before=None,
+    )
+
+    # Build sort object
+    sort = TriggerSort(field=sort_field, order=sort_order)
+
+    # Get paginated triggers from service
+    result = await trigger_service.get_multi(
+        db=db,
+        page=page,
+        size=size,
+        filters=filters,
+        sort=sort,
+        tenant_id=tenant_id,
+    )
+
+    logger.info(f"Listed {len(result['items'])} triggers for tenant {tenant_id}")
+    return result
+
+
+@router.get("/{trigger_id}", response_model=TriggerRead)
+async def get_trigger(
+    _request: Request,
+    trigger_id: str,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    current_user: Annotated[dict, Depends(get_current_user)],
+) -> TriggerRead:
+    """
+    Get a single trigger by ID.
+
+    Returns trigger with its type-specific configuration.
+    """
+    # Check if user has a tenant
+    if not current_user.get("tenant_id"):
+        raise ForbiddenException("User is not associated with any tenant")
+
+    tenant_id = str(current_user["tenant_id"])
+
+    # Validate trigger_id is a valid UUID
+    try:
+        uuid_pkg.UUID(trigger_id)
+    except ValueError:
+        raise BadRequestException("Invalid trigger ID format")
+
+    # Get trigger from service
+    trigger = await trigger_service.get_trigger_by_id(
+        db=db,
+        trigger_id=trigger_id,
+        tenant_id=tenant_id,
+    )
+
+    if not trigger:
+        raise NotFoundException(f"Trigger {trigger_id} not found")
+
+    return trigger
+
+
+@router.delete("/{trigger_id}", status_code=204)
+async def delete_trigger(
+    _request: Request,
+    trigger_id: str,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    current_user: Annotated[dict, Depends(get_current_user)],
+    hard_delete: bool = Query(False, description="Permanently delete the trigger"),
+) -> None:
+    """
+    Delete a trigger.
+
+    By default performs a soft delete. Set hard_delete=true for permanent deletion.
+    """
+    # Check if user has a tenant
+    if not current_user.get("tenant_id"):
+        raise ForbiddenException("User is not associated with any tenant")
+
+    tenant_id = str(current_user["tenant_id"])
+
+    # Validate trigger_id is a valid UUID
+    try:
+        uuid_pkg.UUID(trigger_id)
+    except ValueError:
+        raise BadRequestException("Invalid trigger ID format")
+
+    # Delete the trigger
+    deleted = await trigger_service.delete_trigger(
+        db=db,
+        trigger_id=trigger_id,
+        tenant_id=tenant_id,
+        is_hard_delete=hard_delete,
+    )
+
+    if not deleted:
+        raise NotFoundException(f"Trigger {trigger_id} not found")
+
+    logger.info(f"Deleted trigger {trigger_id} for tenant {tenant_id} (hard={hard_delete})")
+
+
+@router.put("/{trigger_id}/enable", response_model=TriggerRead)
+async def enable_trigger(
+    _request: Request,
+    trigger_id: str,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    current_user: Annotated[dict, Depends(get_current_user)],
+) -> TriggerRead:
+    """
+    Enable a trigger to start processing.
+
+    Sets the trigger's active status to true.
+    """
+    # Check if user has a tenant
+    if not current_user.get("tenant_id"):
+        raise ForbiddenException("User is not associated with any tenant")
+
+    tenant_id = str(current_user["tenant_id"])
+
+    # Validate trigger_id is a valid UUID
+    try:
+        uuid_pkg.UUID(trigger_id)
+    except ValueError:
+        raise BadRequestException("Invalid trigger ID format")
+
+    # Update the trigger to set active=True
+    trigger = await trigger_service.update_trigger(
+        db=db,
+        trigger_id=trigger_id,
+        trigger_in=ENABLE_TRIGGER_UPDATE,
+        tenant_id=tenant_id,
+    )
+
+    if not trigger:
+        raise NotFoundException(f"Trigger {trigger_id} not found")
+
+    logger.info(f"Enabled trigger {trigger_id} for tenant {tenant_id}")
+    return trigger
+
+
+@router.put("/{trigger_id}/disable", response_model=TriggerRead)
+async def disable_trigger(
+    _request: Request,
+    trigger_id: str,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    current_user: Annotated[dict, Depends(get_current_user)],
+) -> TriggerRead:
+    """
+    Disable a trigger to stop processing.
+
+    Sets the trigger's active status to false.
+    """
+    # Check if user has a tenant
+    if not current_user.get("tenant_id"):
+        raise ForbiddenException("User is not associated with any tenant")
+
+    tenant_id = str(current_user["tenant_id"])
+
+    # Validate trigger_id is a valid UUID
+    try:
+        uuid_pkg.UUID(trigger_id)
+    except ValueError:
+        raise BadRequestException("Invalid trigger ID format")
+
+    # Update the trigger to set active=False
+    trigger = await trigger_service.update_trigger(
+        db=db,
+        trigger_id=trigger_id,
+        trigger_in=DISABLE_TRIGGER_UPDATE,
+        tenant_id=tenant_id,
+    )
+
+    if not trigger:
+        raise NotFoundException(f"Trigger {trigger_id} not found")
+
+    logger.info(f"Disabled trigger {trigger_id} for tenant {tenant_id}")
+    return trigger
+
+
+@router.post("/email", response_model=TriggerRead, status_code=201)
+async def create_email_trigger(
+    _request: Request,
+    email_config: EmailTriggerBase,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    current_user: Annotated[dict, Depends(get_current_user)],
+    name: str = Query(..., description="Trigger name"),
+    slug: str = Query(..., description="Trigger slug"),
+    description: Optional[str] = Query(None, description="Trigger description"),
+) -> TriggerRead:
+    """
+    Create a new email trigger.
+
+    Validates email addresses and SMTP configuration.
+    """
+    # Check if user has a tenant
+    if not current_user.get("tenant_id"):
+        raise ForbiddenException("User is not associated with any tenant")
+
+    tenant_id = current_user["tenant_id"]
+
+    # Check if slug already exists for this tenant
+    existing = await trigger_service.get_trigger_by_slug(
+        db=db,
+        slug=slug,
+        tenant_id=tenant_id,
+    )
+
+    if existing:
+        raise DuplicateValueException(f"Trigger with slug '{slug}' already exists")
+
+    # Create the trigger
+    trigger_in = TriggerCreate(
+        tenant_id=tenant_id,
+        name=name,
+        slug=slug,
+        description=description,
+        trigger_type="email",
+        email_config=email_config,
+        webhook_config=None,
+    )
+
+    try:
+        trigger = await trigger_service.create_trigger(
+            db=db,
+            trigger_in=trigger_in,
+            tenant_id=tenant_id,
+        )
+        logger.info(f"Created email trigger {trigger.id} for tenant {tenant_id}")
+        return trigger
+    except ValidationError as e:
+        logger.warning(f"Email trigger validation failed: {e}")
+        raise BadRequestException(f"Validation failed: {str(e)}")
+    except IntegrityError as e:
+        logger.warning(f"Email trigger integrity constraint violated: {e}")
+        raise DuplicateValueException("Trigger with this configuration already exists")
+    except Exception as e:
+        logger.error(f"Failed to create email trigger: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.put("/email/{trigger_id}", response_model=TriggerRead)
+async def update_email_trigger(
+    _request: Request,
+    trigger_id: str,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    current_user: Annotated[dict, Depends(get_current_user)],
+    name: Optional[str] = Query(None, description="Trigger name"),
+    slug: Optional[str] = Query(None, description="Trigger slug"),
+    description: Optional[str] = Query(None, description="Trigger description"),
+    active: Optional[bool] = Query(None, description="Active status"),
+    email_config: Optional[EmailTriggerBase] = None,
+) -> TriggerRead:
+    """
+    Update an existing email trigger.
+
+    Only email triggers can be updated through this endpoint.
+    """
+    # Check if user has a tenant
+    if not current_user.get("tenant_id"):
+        raise ForbiddenException("User is not associated with any tenant")
+
+    tenant_id = str(current_user["tenant_id"])
+
+    # Validate trigger_id is a valid UUID
+    try:
+        uuid_pkg.UUID(trigger_id)
+    except ValueError:
+        raise BadRequestException("Invalid trigger ID format")
+
+    # Get existing trigger to verify it's an email trigger
+    existing_trigger = await trigger_service.get_trigger_by_id(
+        db=db,
+        trigger_id=trigger_id,
+        tenant_id=tenant_id,
+    )
+
+    if not existing_trigger:
+        raise NotFoundException(f"Trigger {trigger_id} not found")
+
+    if existing_trigger.trigger_type != "email":
+        raise BadRequestException(f"Trigger {trigger_id} is not an email trigger")
+
+    # Check if updating slug to an existing one
+    if slug and slug != existing_trigger.slug:
+        existing_slug = await trigger_service.get_trigger_by_slug(
+            db=db,
+            slug=slug,
+            tenant_id=tenant_id,
+        )
+        if existing_slug:
+            raise DuplicateValueException(f"Trigger with slug '{slug}' already exists")
+
+    # Update the trigger
+    trigger_update = TriggerUpdate(
+        name=name,
+        slug=slug,
+        description=description,
+        active=active,
+        email_config=email_config,
+        webhook_config=None,
+    )
+
+    trigger = await trigger_service.update_trigger(
+        db=db,
+        trigger_id=trigger_id,
+        trigger_in=trigger_update,
+        tenant_id=tenant_id,
+    )
+
+    if not trigger:
+        raise NotFoundException(f"Trigger {trigger_id} not found")
+
+    logger.info(f"Updated email trigger {trigger_id} for tenant {tenant_id}")
+    return trigger
+
+
+@router.post(
+    "/email/{trigger_id}/test",
+    response_model=TriggerTestResult,
+    dependencies=[Depends(rate_limiter_dependency)],
+)
+async def send_test_email_trigger(
+    _request: Request,
+    trigger_id: str,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    current_user: Annotated[dict, Depends(get_current_user)],
+    test_data: dict[str, Any] = Body(default_factory=dict, description="Sample data for test"),
+) -> TriggerTestResult:
+    """
+    Send a test email using the trigger configuration.
+
+    Rate limited to prevent abuse.
+    """
+    # Check if user has a tenant
+    if not current_user.get("tenant_id"):
+        raise ForbiddenException("User is not associated with any tenant")
+
+    tenant_id = str(current_user["tenant_id"])
+
+    # Validate trigger_id is a valid UUID
+    try:
+        uuid_pkg.UUID(trigger_id)
+    except ValueError:
+        raise BadRequestException("Invalid trigger ID format")
+
+    # Get trigger to verify it exists and is an email trigger
+    trigger = await trigger_service.get_trigger_by_id(
+        db=db,
+        trigger_id=trigger_id,
+        tenant_id=tenant_id,
+    )
+
+    if not trigger:
+        raise NotFoundException(f"Trigger {trigger_id} not found")
+
+    if trigger.trigger_type != "email":
+        raise BadRequestException(f"Trigger {trigger_id} is not an email trigger")
+
+    # Test the trigger
+    test_request = TriggerTestRequest(
+        trigger_id=uuid_pkg.UUID(trigger_id),
+        test_data=test_data,
+    )
+
+    try:
+        result = await trigger_service.test_trigger(
+            db=db,
+            test_request=test_request,
+        )
+        logger.info(f"Tested email trigger {trigger_id} for tenant {tenant_id}: success={result.success}")
+        return result
+    except Exception as e:
+        logger.error(f"Failed to test email trigger {trigger_id}: {e}")
+        return TriggerTestResult(
+            trigger_id=uuid_pkg.UUID(trigger_id),
+            success=False,
+            error=str(e),
+        )
+
+
+@router.post("/webhook", response_model=TriggerRead, status_code=201)
+async def create_webhook_trigger(
+    _request: Request,
+    webhook_config: WebhookTriggerBase,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    current_user: Annotated[dict, Depends(get_current_user)],
+    name: str = Query(..., description="Trigger name"),
+    slug: str = Query(..., description="Trigger slug"),
+    description: Optional[str] = Query(None, description="Trigger description"),
+) -> TriggerRead:
+    """
+    Create a new webhook trigger.
+
+    Validates URL format and HTTP configuration.
+    """
+    # Check if user has a tenant
+    if not current_user.get("tenant_id"):
+        raise ForbiddenException("User is not associated with any tenant")
+
+    tenant_id = current_user["tenant_id"]
+
+    # Check if slug already exists for this tenant
+    existing = await trigger_service.get_trigger_by_slug(
+        db=db,
+        slug=slug,
+        tenant_id=tenant_id,
+    )
+
+    if existing:
+        raise DuplicateValueException(f"Trigger with slug '{slug}' already exists")
+
+    # Create the trigger
+    trigger_in = TriggerCreate(
+        tenant_id=tenant_id,
+        name=name,
+        slug=slug,
+        description=description,
+        trigger_type="webhook",
+        email_config=None,
+        webhook_config=webhook_config,
+    )
+
+    try:
+        trigger = await trigger_service.create_trigger(
+            db=db,
+            trigger_in=trigger_in,
+            tenant_id=tenant_id,
+        )
+        logger.info(f"Created webhook trigger {trigger.id} for tenant {tenant_id}")
+        return trigger
+    except ValidationError as e:
+        logger.warning(f"Webhook trigger validation failed: {e}")
+        raise BadRequestException(f"Validation failed: {str(e)}")
+    except IntegrityError as e:
+        logger.warning(f"Webhook trigger integrity constraint violated: {e}")
+        raise DuplicateValueException("Trigger with this configuration already exists")
+    except Exception as e:
+        logger.error(f"Failed to create webhook trigger: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.put("/webhook/{trigger_id}", response_model=TriggerRead)
+async def update_webhook_trigger(
+    _request: Request,
+    trigger_id: str,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    current_user: Annotated[dict, Depends(get_current_user)],
+    name: Optional[str] = Query(None, description="Trigger name"),
+    slug: Optional[str] = Query(None, description="Trigger slug"),
+    description: Optional[str] = Query(None, description="Trigger description"),
+    active: Optional[bool] = Query(None, description="Active status"),
+    webhook_config: Optional[WebhookTriggerBase] = None,
+) -> TriggerRead:
+    """
+    Update an existing webhook trigger.
+
+    Only webhook triggers can be updated through this endpoint.
+    """
+    # Check if user has a tenant
+    if not current_user.get("tenant_id"):
+        raise ForbiddenException("User is not associated with any tenant")
+
+    tenant_id = str(current_user["tenant_id"])
+
+    # Validate trigger_id is a valid UUID
+    try:
+        uuid_pkg.UUID(trigger_id)
+    except ValueError:
+        raise BadRequestException("Invalid trigger ID format")
+
+    # Get existing trigger to verify it's a webhook trigger
+    existing_trigger = await trigger_service.get_trigger_by_id(
+        db=db,
+        trigger_id=trigger_id,
+        tenant_id=tenant_id,
+    )
+
+    if not existing_trigger:
+        raise NotFoundException(f"Trigger {trigger_id} not found")
+
+    if existing_trigger.trigger_type != "webhook":
+        raise BadRequestException(f"Trigger {trigger_id} is not a webhook trigger")
+
+    # Check if updating slug to an existing one
+    if slug and slug != existing_trigger.slug:
+        existing_slug = await trigger_service.get_trigger_by_slug(
+            db=db,
+            slug=slug,
+            tenant_id=tenant_id,
+        )
+        if existing_slug:
+            raise DuplicateValueException(f"Trigger with slug '{slug}' already exists")
+
+    # Update the trigger
+    trigger_update = TriggerUpdate(
+        name=name,
+        slug=slug,
+        description=description,
+        active=active,
+        email_config=None,
+        webhook_config=webhook_config,
+    )
+
+    trigger = await trigger_service.update_trigger(
+        db=db,
+        trigger_id=trigger_id,
+        trigger_in=trigger_update,
+        tenant_id=tenant_id,
+    )
+
+    if not trigger:
+        raise NotFoundException(f"Trigger {trigger_id} not found")
+
+    logger.info(f"Updated webhook trigger {trigger_id} for tenant {tenant_id}")
+    return trigger
+
+
+@router.post(
+    "/webhook/{trigger_id}/test",
+    response_model=TriggerTestResult,
+    dependencies=[Depends(rate_limiter_dependency)],
+)
+async def send_test_webhook_trigger(
+    _request: Request,
+    trigger_id: str,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    current_user: Annotated[dict, Depends(get_current_user)],
+    test_data: dict[str, Any] = Body(default_factory=dict, description="Sample data for test"),
+) -> TriggerTestResult:
+    """
+    Send a test webhook using the trigger configuration.
+
+    Rate limited to prevent abuse.
+    """
+    # Check if user has a tenant
+    if not current_user.get("tenant_id"):
+        raise ForbiddenException("User is not associated with any tenant")
+
+    tenant_id = str(current_user["tenant_id"])
+
+    # Validate trigger_id is a valid UUID
+    try:
+        uuid_pkg.UUID(trigger_id)
+    except ValueError:
+        raise BadRequestException("Invalid trigger ID format")
+
+    # Get trigger to verify it exists and is a webhook trigger
+    trigger = await trigger_service.get_trigger_by_id(
+        db=db,
+        trigger_id=trigger_id,
+        tenant_id=tenant_id,
+    )
+
+    if not trigger:
+        raise NotFoundException(f"Trigger {trigger_id} not found")
+
+    if trigger.trigger_type != "webhook":
+        raise BadRequestException(f"Trigger {trigger_id} is not a webhook trigger")
+
+    # Test the trigger
+    test_request = TriggerTestRequest(
+        trigger_id=uuid_pkg.UUID(trigger_id),
+        test_data=test_data,
+    )
+
+    try:
+        result = await trigger_service.test_trigger(
+            db=db,
+            test_request=test_request,
+        )
+        logger.info(f"Tested webhook trigger {trigger_id} for tenant {tenant_id}: success={result.success}")
+        return result
+    except Exception as e:
+        logger.error(f"Failed to test webhook trigger {trigger_id}: {e}")
+        return TriggerTestResult(
+            trigger_id=uuid_pkg.UUID(trigger_id),
+            success=False,
+            error=str(e),
+        )
+
+
+@router.post("/{trigger_id}/validate", response_model=TriggerValidationResult)
+async def validate_trigger(
+    _request: Request,
+    trigger_id: str,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    current_user: Annotated[dict, Depends(get_current_user)],
+    test_connection: bool = Query(True, description="Test the trigger connection/credentials"),
+) -> TriggerValidationResult:
+    """
+    Validate a trigger configuration.
+
+    Checks that the trigger configuration is valid and can be executed.
+    """
+    # Check if user has a tenant
+    if not current_user.get("tenant_id"):
+        raise ForbiddenException("User is not associated with any tenant")
+
+    tenant_id = str(current_user["tenant_id"])
+
+    # Validate trigger_id is a valid UUID
+    try:
+        trigger_uuid = uuid_pkg.UUID(trigger_id)
+    except ValueError:
+        raise BadRequestException("Invalid trigger ID format")
+
+    # Get trigger to verify it exists
+    trigger = await trigger_service.get_trigger_by_id(
+        db=db,
+        trigger_id=trigger_id,
+        tenant_id=tenant_id,
+    )
+
+    if not trigger:
+        raise NotFoundException(f"Trigger {trigger_id} not found")
+
+    # Validate the trigger
+    validation_request = TriggerValidationRequest(
+        trigger_id=trigger_uuid,
+        test_connection=test_connection,
+    )
+
+    result = await trigger_service.validate_trigger(
+        db=db,
+        validation_request=validation_request,
+    )
+
+    logger.info(f"Validated trigger {trigger_id}: valid={result.is_valid}, errors={len(result.errors)}")
+    return result

--- a/tests/api/v1/test_triggers.py
+++ b/tests/api/v1/test_triggers.py
@@ -1,0 +1,1059 @@
+"""
+Comprehensive tests for trigger API endpoints.
+Tests all CRUD operations, type-specific endpoints, and test/validation endpoints.
+"""
+
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.app.api.v1.triggers import (
+    create_email_trigger,
+    create_webhook_trigger,
+    delete_trigger,
+    disable_trigger,
+    enable_trigger,
+    get_trigger,
+    list_triggers,
+    send_test_email_trigger,
+    send_test_webhook_trigger,
+    update_email_trigger,
+    update_webhook_trigger,
+    validate_trigger,
+)
+from src.app.core.exceptions.http_exceptions import (
+    BadRequestException,
+    DuplicateValueException,
+    ForbiddenException,
+    NotFoundException,
+)
+from src.app.schemas.trigger import (
+    EmailTriggerBase,
+    EmailTriggerRead,
+    TriggerRead,
+    TriggerTestResult,
+    TriggerValidationResult,
+    WebhookTriggerBase,
+    WebhookTriggerRead,
+)
+
+
+@pytest.fixture
+def sample_tenant_id():
+    """Generate a sample tenant ID."""
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def sample_trigger_id():
+    """Generate a sample trigger ID."""
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def current_user_with_tenant(sample_tenant_id):
+    """Mock current user with tenant association."""
+    return {
+        "id": 1,
+        "username": "test_user",
+        "email": "test@example.com",
+        "tenant_id": sample_tenant_id,
+        "is_superuser": False,
+    }
+
+
+@pytest.fixture
+def current_user_without_tenant():
+    """Mock current user without tenant association."""
+    return {
+        "id": 2,
+        "username": "no_tenant_user",
+        "email": "no_tenant@example.com",
+        "tenant_id": None,
+        "is_superuser": False,
+    }
+
+
+@pytest.fixture
+def sample_email_config():
+    """Generate sample email trigger configuration."""
+    return EmailTriggerBase(
+        host="smtp.gmail.com",
+        port=587,
+        username_type="Plain",
+        username_value="test@example.com",
+        password_type="Environment",
+        password_value="SMTP_PASSWORD",
+        sender="noreply@example.com",
+        recipients=["user1@example.com", "user2@example.com"],
+        message_title="Test Alert: {{event_name}}",
+        message_body="Alert triggered at {{timestamp}}",
+    )
+
+
+@pytest.fixture
+def sample_webhook_config():
+    """Generate sample webhook trigger configuration."""
+    return WebhookTriggerBase(
+        url_type="Plain",
+        url_value="https://webhook.site/test",
+        method="POST",
+        headers={"Content-Type": "application/json"},
+        secret_type="Environment",
+        secret_value="WEBHOOK_SECRET",
+        message_title="Test Alert",
+        message_body="{{event_data}}",
+    )
+
+
+@pytest.fixture
+def sample_email_trigger_read(sample_trigger_id, sample_tenant_id):
+    """Generate sample email trigger read data."""
+    return TriggerRead(
+        id=uuid.UUID(sample_trigger_id),
+        tenant_id=sample_tenant_id,
+        name="Test Email Trigger",
+        slug="test-email-trigger",
+        trigger_type="email",
+        description="Test email trigger description",
+        active=True,
+        validated=True,
+        validation_errors=None,
+        last_validated_at=datetime.utcnow(),
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+        email_config=EmailTriggerRead(
+            trigger_id=uuid.UUID(sample_trigger_id),
+            host="smtp.gmail.com",
+            port=587,
+            username_type="Plain",
+            username_value="test@example.com",
+            password_type="Environment",
+            password_value="SMTP_PASSWORD",
+            sender="noreply@example.com",
+            recipients=["user1@example.com"],
+            message_title="Alert",
+            message_body="Alert body",
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        ),
+        webhook_config=None,
+    )
+
+
+@pytest.fixture
+def sample_webhook_trigger_read(sample_trigger_id, sample_tenant_id):
+    """Generate sample webhook trigger read data."""
+    return TriggerRead(
+        id=uuid.UUID(sample_trigger_id),
+        tenant_id=sample_tenant_id,
+        name="Test Webhook Trigger",
+        slug="test-webhook-trigger",
+        trigger_type="webhook",
+        description="Test webhook trigger description",
+        active=True,
+        validated=True,
+        validation_errors=None,
+        last_validated_at=datetime.utcnow(),
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+        email_config=None,
+        webhook_config=WebhookTriggerRead(
+            trigger_id=uuid.UUID(sample_trigger_id),
+            url_type="Plain",
+            url_value="https://webhook.site/test",
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            secret_type=None,
+            secret_value=None,
+            message_title="Alert",
+            message_body="Alert body",
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        ),
+    )
+
+
+@pytest.fixture
+def mock_trigger_service():
+    """Mock trigger service."""
+    with patch("src.app.api.v1.triggers.trigger_service") as mock_service:
+        yield mock_service
+
+
+class TestListTriggers:
+    """Test GET /triggers endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_list_triggers_success(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_email_trigger_read,
+        sample_webhook_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test successful trigger listing with pagination."""
+        # Mock service response
+        mock_trigger_service.get_multi = AsyncMock(
+            return_value={
+                "items": [sample_email_trigger_read, sample_webhook_trigger_read],
+                "total": 2,
+                "page": 1,
+                "size": 50,
+                "pages": 1,
+            }
+        )
+
+        result = await list_triggers(
+            _request=Mock(),
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            page=1,
+            size=50,
+            name=None,
+            slug=None,
+            trigger_type=None,
+            active=None,
+            validated=None,
+            sort_field="created_at",
+            sort_order="desc",
+        )
+
+        assert result["total"] == 2
+        assert len(result["items"]) == 2
+        assert result["items"][0] == sample_email_trigger_read
+        assert result["items"][1] == sample_webhook_trigger_read
+        mock_trigger_service.get_multi.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_triggers_with_type_filter(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_email_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test trigger listing filtered by type."""
+        mock_trigger_service.get_multi = AsyncMock(
+            return_value={
+                "items": [sample_email_trigger_read],
+                "total": 1,
+                "page": 1,
+                "size": 50,
+                "pages": 1,
+            }
+        )
+
+        result = await list_triggers(
+            _request=Mock(),
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            page=1,
+            size=50,
+            name=None,
+            slug=None,
+            trigger_type="email",
+            active=None,
+            validated=None,
+            sort_field="created_at",
+            sort_order="desc",
+        )
+
+        assert result["total"] == 1
+        assert result["items"][0].trigger_type == "email"
+
+        # Verify filter was constructed correctly
+        call_args = mock_trigger_service.get_multi.call_args
+        filters = call_args.kwargs["filters"]
+        assert filters.trigger_type == "email"
+
+    @pytest.mark.asyncio
+    async def test_list_triggers_no_tenant(
+        self,
+        mock_db,
+        current_user_without_tenant,
+    ):
+        """Test trigger listing without tenant association."""
+        with pytest.raises(ForbiddenException, match="User is not associated with any tenant"):
+            await list_triggers(
+                _request=Mock(),
+                db=mock_db,
+                current_user=current_user_without_tenant,
+                page=1,
+                size=50,
+                name=None,
+                slug=None,
+                trigger_type=None,
+                active=None,
+                validated=None,
+                sort_field="created_at",
+                sort_order="desc",
+            )
+
+
+class TestGetTrigger:
+    """Test GET /triggers/{id} endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_trigger_success(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_email_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test successful single trigger retrieval."""
+        mock_trigger_service.get_trigger_by_id = AsyncMock(return_value=sample_email_trigger_read)
+
+        result = await get_trigger(
+            _request=Mock(),
+            trigger_id=sample_trigger_id,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+        )
+
+        assert result == sample_email_trigger_read
+        mock_trigger_service.get_trigger_by_id.assert_called_once_with(
+            db=mock_db,
+            trigger_id=sample_trigger_id,
+            tenant_id=str(current_user_with_tenant["tenant_id"]),
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_trigger_invalid_id(
+        self,
+        mock_db,
+        current_user_with_tenant,
+    ):
+        """Test trigger retrieval with invalid UUID."""
+        with pytest.raises(BadRequestException, match="Invalid trigger ID format"):
+            await get_trigger(
+                _request=Mock(),
+                trigger_id="invalid-uuid",
+                db=mock_db,
+                current_user=current_user_with_tenant,
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_trigger_not_found(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        mock_trigger_service,
+    ):
+        """Test trigger retrieval when trigger doesn't exist."""
+        mock_trigger_service.get_trigger_by_id = AsyncMock(return_value=None)
+
+        with pytest.raises(NotFoundException, match=f"Trigger {sample_trigger_id} not found"):
+            await get_trigger(
+                _request=Mock(),
+                trigger_id=sample_trigger_id,
+                db=mock_db,
+                current_user=current_user_with_tenant,
+            )
+
+
+class TestCreateEmailTrigger:
+    """Test POST /triggers/email endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_create_email_trigger_success(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_email_config,
+        sample_email_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test successful email trigger creation."""
+        mock_trigger_service.get_trigger_by_slug = AsyncMock(return_value=None)
+        mock_trigger_service.create_trigger = AsyncMock(return_value=sample_email_trigger_read)
+
+        result = await create_email_trigger(
+            _request=Mock(),
+            email_config=sample_email_config,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            name="Test Email Trigger",
+            slug="test-email-trigger",
+            description="Test description",
+        )
+
+        assert result == sample_email_trigger_read
+        mock_trigger_service.create_trigger.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_email_trigger_duplicate_slug(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_email_config,
+        sample_email_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test email trigger creation with duplicate slug."""
+        mock_trigger_service.get_trigger_by_slug = AsyncMock(return_value=sample_email_trigger_read)
+
+        with pytest.raises(
+            DuplicateValueException,
+            match="Trigger with slug 'test-email-trigger' already exists",
+        ):
+            await create_email_trigger(
+                _request=Mock(),
+                email_config=sample_email_config,
+                db=mock_db,
+                current_user=current_user_with_tenant,
+                name="Test Email Trigger",
+                slug="test-email-trigger",
+                description="Test description",
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_email_trigger_invalid_email(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        mock_trigger_service,
+    ):
+        """Test email trigger creation with invalid email addresses."""
+        invalid_email_config = EmailTriggerBase(
+            host="smtp.gmail.com",
+            port=587,
+            username_type="Plain",
+            username_value="test@example.com",
+            password_type="Environment",
+            password_value="SMTP_PASSWORD",
+            sender="invalid-email",  # Invalid email
+            recipients=["user1@example.com"],
+            message_title="Test",
+            message_body="Test",
+        )
+
+        mock_trigger_service.get_trigger_by_slug = AsyncMock(return_value=None)
+        mock_trigger_service.create_trigger = AsyncMock(
+            side_effect=ValueError("Invalid email address")
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_email_trigger(
+                _request=Mock(),
+                email_config=invalid_email_config,
+                db=mock_db,
+                current_user=current_user_with_tenant,
+                name="Test",
+                slug="test",
+                description="Test",
+            )
+
+        assert exc_info.value.status_code == 500
+
+
+class TestCreateWebhookTrigger:
+    """Test POST /triggers/webhook endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_create_webhook_trigger_success(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_webhook_config,
+        sample_webhook_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test successful webhook trigger creation."""
+        mock_trigger_service.get_trigger_by_slug = AsyncMock(return_value=None)
+        mock_trigger_service.create_trigger = AsyncMock(return_value=sample_webhook_trigger_read)
+
+        result = await create_webhook_trigger(
+            _request=Mock(),
+            webhook_config=sample_webhook_config,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            name="Test Webhook Trigger",
+            slug="test-webhook-trigger",
+            description="Test description",
+        )
+
+        assert result == sample_webhook_trigger_read
+        mock_trigger_service.create_trigger.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_webhook_trigger_invalid_method(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        mock_trigger_service,
+    ):
+        """Test webhook trigger creation with invalid HTTP method."""
+        # This should raise validation error from pydantic
+        from pydantic import ValidationError
+        
+        with pytest.raises(ValidationError):  # Will be pydantic validation error
+            invalid_webhook_config = WebhookTriggerBase(
+                url_type="Plain",
+                url_value="https://webhook.site/test",
+                method="INVALID",  # Invalid method
+                headers={},
+                secret_type=None,
+                secret_value=None,
+                message_title="Test",
+                message_body="Test",
+            )
+
+
+class TestUpdateEmailTrigger:
+    """Test PUT /triggers/email/{id} endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_update_email_trigger_success(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_email_trigger_read,
+        sample_email_config,
+        mock_trigger_service,
+    ):
+        """Test successful email trigger update."""
+        updated_trigger = sample_email_trigger_read.model_copy()
+        updated_trigger.name = "Updated Email Trigger"
+
+        mock_trigger_service.get_trigger_by_id = AsyncMock(return_value=sample_email_trigger_read)
+        mock_trigger_service.get_trigger_by_slug = AsyncMock(return_value=None)
+        mock_trigger_service.update_trigger = AsyncMock(return_value=updated_trigger)
+
+        result = await update_email_trigger(
+            _request=Mock(),
+            trigger_id=sample_trigger_id,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            name="Updated Email Trigger",
+            slug=None,
+            description=None,
+            active=None,
+            email_config=sample_email_config,
+        )
+
+        assert result.name == "Updated Email Trigger"
+        mock_trigger_service.update_trigger.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_email_trigger_wrong_type(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_webhook_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test updating a non-email trigger through email endpoint."""
+        mock_trigger_service.get_trigger_by_id = AsyncMock(return_value=sample_webhook_trigger_read)
+
+        with pytest.raises(
+            BadRequestException,
+            match=f"Trigger {sample_trigger_id} is not an email trigger",
+        ):
+            await update_email_trigger(
+                _request=Mock(),
+                trigger_id=sample_trigger_id,
+                db=mock_db,
+                current_user=current_user_with_tenant,
+                name="Updated",
+                slug=None,
+                description=None,
+                active=None,
+                email_config=None,
+            )
+
+
+class TestUpdateWebhookTrigger:
+    """Test PUT /triggers/webhook/{id} endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_update_webhook_trigger_success(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_webhook_trigger_read,
+        sample_webhook_config,
+        mock_trigger_service,
+    ):
+        """Test successful webhook trigger update."""
+        updated_trigger = sample_webhook_trigger_read.model_copy()
+        updated_trigger.name = "Updated Webhook Trigger"
+
+        mock_trigger_service.get_trigger_by_id = AsyncMock(return_value=sample_webhook_trigger_read)
+        mock_trigger_service.get_trigger_by_slug = AsyncMock(return_value=None)
+        mock_trigger_service.update_trigger = AsyncMock(return_value=updated_trigger)
+
+        result = await update_webhook_trigger(
+            _request=Mock(),
+            trigger_id=sample_trigger_id,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            name="Updated Webhook Trigger",
+            slug=None,
+            description=None,
+            active=None,
+            webhook_config=sample_webhook_config,
+        )
+
+        assert result.name == "Updated Webhook Trigger"
+        mock_trigger_service.update_trigger.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_webhook_trigger_wrong_type(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_email_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test updating a non-webhook trigger through webhook endpoint."""
+        mock_trigger_service.get_trigger_by_id = AsyncMock(return_value=sample_email_trigger_read)
+
+        with pytest.raises(
+            BadRequestException,
+            match=f"Trigger {sample_trigger_id} is not a webhook trigger",
+        ):
+            await update_webhook_trigger(
+                _request=Mock(),
+                trigger_id=sample_trigger_id,
+                db=mock_db,
+                current_user=current_user_with_tenant,
+                name="Updated",
+                slug=None,
+                description=None,
+                active=None,
+                webhook_config=None,
+            )
+
+
+class TestDeleteTrigger:
+    """Test DELETE /triggers/{id} endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_delete_trigger_soft_delete(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        mock_trigger_service,
+    ):
+        """Test soft delete of trigger."""
+        mock_trigger_service.delete_trigger = AsyncMock(return_value=True)
+
+        await delete_trigger(
+            _request=Mock(),
+            trigger_id=sample_trigger_id,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            hard_delete=False,
+        )
+
+        mock_trigger_service.delete_trigger.assert_called_once_with(
+            db=mock_db,
+            trigger_id=sample_trigger_id,
+            tenant_id=str(current_user_with_tenant["tenant_id"]),
+            is_hard_delete=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_trigger_hard_delete(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        mock_trigger_service,
+    ):
+        """Test hard delete of trigger."""
+        mock_trigger_service.delete_trigger = AsyncMock(return_value=True)
+
+        await delete_trigger(
+            _request=Mock(),
+            trigger_id=sample_trigger_id,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            hard_delete=True,
+        )
+
+        mock_trigger_service.delete_trigger.assert_called_once_with(
+            db=mock_db,
+            trigger_id=sample_trigger_id,
+            tenant_id=str(current_user_with_tenant["tenant_id"]),
+            is_hard_delete=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_trigger_not_found(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        mock_trigger_service,
+    ):
+        """Test delete when trigger doesn't exist."""
+        mock_trigger_service.delete_trigger = AsyncMock(return_value=False)
+
+        with pytest.raises(NotFoundException, match=f"Trigger {sample_trigger_id} not found"):
+            await delete_trigger(
+                _request=Mock(),
+                trigger_id=sample_trigger_id,
+                db=mock_db,
+                current_user=current_user_with_tenant,
+                hard_delete=False,
+            )
+
+
+class TestEnableDisableTrigger:
+    """Test PUT /triggers/{id}/enable and /disable endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_enable_trigger_success(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_email_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test successful trigger enable."""
+        enabled_trigger = sample_email_trigger_read.model_copy()
+        enabled_trigger.active = True
+
+        mock_trigger_service.update_trigger = AsyncMock(return_value=enabled_trigger)
+
+        result = await enable_trigger(
+            _request=Mock(),
+            trigger_id=sample_trigger_id,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+        )
+
+        assert result.active is True
+
+        # Verify correct update was called
+        call_args = mock_trigger_service.update_trigger.call_args
+        assert call_args.kwargs["trigger_in"].active is True
+
+    @pytest.mark.asyncio
+    async def test_disable_trigger_success(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_email_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test successful trigger disable."""
+        disabled_trigger = sample_email_trigger_read.model_copy()
+        disabled_trigger.active = False
+
+        mock_trigger_service.update_trigger = AsyncMock(return_value=disabled_trigger)
+
+        result = await disable_trigger(
+            _request=Mock(),
+            trigger_id=sample_trigger_id,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+        )
+
+        assert result.active is False
+
+        # Verify correct update was called
+        call_args = mock_trigger_service.update_trigger.call_args
+        assert call_args.kwargs["trigger_in"].active is False
+
+
+class TestEmailTriggerTest:
+    """Test POST /triggers/email/{id}/test endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_test_email_trigger_success(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_email_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test successful email trigger test."""
+        test_result = TriggerTestResult(
+            trigger_id=uuid.UUID(sample_trigger_id),
+            success=True,
+            response={"message": "Email sent successfully"},
+            error=None,
+            duration_ms=150,
+        )
+
+        mock_trigger_service.get_trigger_by_id = AsyncMock(return_value=sample_email_trigger_read)
+        mock_trigger_service.test_trigger = AsyncMock(return_value=test_result)
+
+        result = await send_test_email_trigger(
+            _request=Mock(),
+            trigger_id=sample_trigger_id,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            test_data={"event": "test"},
+        )
+
+        assert result.success is True
+        assert result.trigger_id == uuid.UUID(sample_trigger_id)
+        mock_trigger_service.test_trigger.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_test_email_trigger_wrong_type(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_webhook_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test testing a non-email trigger through email test endpoint."""
+        mock_trigger_service.get_trigger_by_id = AsyncMock(return_value=sample_webhook_trigger_read)
+
+        with pytest.raises(
+            BadRequestException,
+            match=f"Trigger {sample_trigger_id} is not an email trigger",
+        ):
+            await send_test_email_trigger(
+                _request=Mock(),
+                trigger_id=sample_trigger_id,
+                db=mock_db,
+                current_user=current_user_with_tenant,
+                test_data={},
+            )
+
+    @pytest.mark.asyncio
+    async def test_test_email_trigger_failure(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_email_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test email trigger test failure."""
+        mock_trigger_service.get_trigger_by_id = AsyncMock(return_value=sample_email_trigger_read)
+        mock_trigger_service.test_trigger = AsyncMock(side_effect=Exception("SMTP connection failed"))
+
+        result = await send_test_email_trigger(
+            _request=Mock(),
+            trigger_id=sample_trigger_id,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            test_data={},
+        )
+
+        assert result.success is False
+        assert "SMTP connection failed" in result.error
+
+
+class TestWebhookTriggerTest:
+    """Test POST /triggers/webhook/{id}/test endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_test_webhook_trigger_success(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_webhook_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test successful webhook trigger test."""
+        test_result = TriggerTestResult(
+            trigger_id=uuid.UUID(sample_trigger_id),
+            success=True,
+            response={"status_code": 200, "body": "OK"},
+            error=None,
+            duration_ms=75,
+        )
+
+        mock_trigger_service.get_trigger_by_id = AsyncMock(return_value=sample_webhook_trigger_read)
+        mock_trigger_service.test_trigger = AsyncMock(return_value=test_result)
+
+        result = await send_test_webhook_trigger(
+            _request=Mock(),
+            trigger_id=sample_trigger_id,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            test_data={"event": "test"},
+        )
+
+        assert result.success is True
+        assert result.trigger_id == uuid.UUID(sample_trigger_id)
+        mock_trigger_service.test_trigger.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_test_webhook_trigger_wrong_type(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_email_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test testing a non-webhook trigger through webhook test endpoint."""
+        mock_trigger_service.get_trigger_by_id = AsyncMock(return_value=sample_email_trigger_read)
+
+        with pytest.raises(
+            BadRequestException,
+            match=f"Trigger {sample_trigger_id} is not a webhook trigger",
+        ):
+            await send_test_webhook_trigger(
+                _request=Mock(),
+                trigger_id=sample_trigger_id,
+                db=mock_db,
+                current_user=current_user_with_tenant,
+                test_data={},
+            )
+
+
+class TestValidateTrigger:
+    """Test POST /triggers/{id}/validate endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_validate_trigger_success(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_email_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test successful trigger validation."""
+        validation_result = TriggerValidationResult(
+            trigger_id=uuid.UUID(sample_trigger_id),
+            is_valid=True,
+            errors=[],
+            warnings=[],
+        )
+
+        mock_trigger_service.get_trigger_by_id = AsyncMock(return_value=sample_email_trigger_read)
+        mock_trigger_service.validate_trigger = AsyncMock(return_value=validation_result)
+
+        result = await validate_trigger(
+            _request=Mock(),
+            trigger_id=sample_trigger_id,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            test_connection=True,
+        )
+
+        assert result.is_valid is True
+        assert len(result.errors) == 0
+        mock_trigger_service.validate_trigger.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_validate_trigger_with_errors(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        sample_trigger_id,
+        sample_email_trigger_read,
+        mock_trigger_service,
+    ):
+        """Test trigger validation with errors."""
+        validation_result = TriggerValidationResult(
+            trigger_id=uuid.UUID(sample_trigger_id),
+            is_valid=False,
+            errors=["Invalid SMTP credentials", "Cannot connect to server"],
+            warnings=["Recipients list is empty"],
+        )
+
+        mock_trigger_service.get_trigger_by_id = AsyncMock(return_value=sample_email_trigger_read)
+        mock_trigger_service.validate_trigger = AsyncMock(return_value=validation_result)
+
+        result = await validate_trigger(
+            _request=Mock(),
+            trigger_id=sample_trigger_id,
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            test_connection=True,
+        )
+
+        assert result.is_valid is False
+        assert len(result.errors) == 2
+        assert len(result.warnings) == 1
+
+
+class TestTriggerEndpointEdgeCases:
+    """Test edge cases and error handling."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_uuid_format(
+        self,
+        mock_db,
+        current_user_with_tenant,
+    ):
+        """Test various endpoints with invalid UUID format."""
+        invalid_id = "not-a-uuid"
+
+        # Test get
+        with pytest.raises(BadRequestException, match="Invalid trigger ID format"):
+            await get_trigger(
+                _request=Mock(),
+                trigger_id=invalid_id,
+                db=mock_db,
+                current_user=current_user_with_tenant,
+            )
+
+        # Test delete
+        with pytest.raises(BadRequestException, match="Invalid trigger ID format"):
+            await delete_trigger(
+                _request=Mock(),
+                trigger_id=invalid_id,
+                db=mock_db,
+                current_user=current_user_with_tenant,
+                hard_delete=False,
+            )
+
+        # Test enable
+        with pytest.raises(BadRequestException, match="Invalid trigger ID format"):
+            await enable_trigger(
+                _request=Mock(),
+                trigger_id=invalid_id,
+                db=mock_db,
+                current_user=current_user_with_tenant,
+            )
+
+    @pytest.mark.asyncio
+    async def test_pagination_boundaries(
+        self,
+        mock_db,
+        current_user_with_tenant,
+        mock_trigger_service,
+    ):
+        """Test pagination with edge cases."""
+        # Test with very large page number
+        mock_trigger_service.get_multi = AsyncMock(
+            return_value={"items": [], "total": 10, "page": 1000, "size": 50, "pages": 1}
+        )
+
+        result = await list_triggers(
+            _request=Mock(),
+            db=mock_db,
+            current_user=current_user_with_tenant,
+            page=1000,
+            size=50,
+            name=None,
+            slug=None,
+            trigger_type=None,
+            active=None,
+            validated=None,
+            sort_field="created_at",
+            sort_order="desc",
+        )
+
+        assert result["items"] == []
+        assert result["page"] == 1000

--- a/uv.lock
+++ b/uv.lock
@@ -235,6 +235,86 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/4e/08b493f1f1d8a5182df0044acc970799b58a8d289608e0d891a03e9d269a/coverage-7.10.4.tar.gz", hash = "sha256:25f5130af6c8e7297fd14634955ba9e1697f47143f289e2a23284177c0061d27", size = 823798, upload-time = "2025-08-17T00:26:43.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/ba/2c9817e62018e7d480d14f684c160b3038df9ff69c5af7d80e97d143e4d1/coverage-7.10.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:05d5f98ec893d4a2abc8bc5f046f2f4367404e7e5d5d18b83de8fde1093ebc4f", size = 216514, upload-time = "2025-08-17T00:24:34.188Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/093412a959a6b6261446221ba9fb23bb63f661a5de70b5d130763c87f916/coverage-7.10.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9267efd28f8994b750d171e58e481e3bbd69e44baed540e4c789f8e368b24b88", size = 216914, upload-time = "2025-08-17T00:24:35.881Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/1f/2fdf4a71cfe93b07eae845ebf763267539a7d8b7e16b062f959d56d7e433/coverage-7.10.4-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4456a039fdc1a89ea60823d0330f1ac6f97b0dbe9e2b6fb4873e889584b085fb", size = 247308, upload-time = "2025-08-17T00:24:37.61Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/16/33f6cded458e84f008b9f6bc379609a6a1eda7bffe349153b9960803fc11/coverage-7.10.4-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c2bfbd2a9f7e68a21c5bd191be94bfdb2691ac40d325bac9ef3ae45ff5c753d9", size = 249241, upload-time = "2025-08-17T00:24:38.919Z" },
+    { url = "https://files.pythonhosted.org/packages/84/98/9c18e47c889be58339ff2157c63b91a219272503ee32b49d926eea2337f2/coverage-7.10.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab7765f10ae1df7e7fe37de9e64b5a269b812ee22e2da3f84f97b1c7732a0d8", size = 251346, upload-time = "2025-08-17T00:24:40.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/07/00a6c0d53e9a22d36d8e95ddd049b860eef8f4b9fd299f7ce34d8e323356/coverage-7.10.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a09b13695166236e171ec1627ff8434b9a9bae47528d0ba9d944c912d33b3d2", size = 249037, upload-time = "2025-08-17T00:24:41.904Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0e/1e1b944d6a6483d07bab5ef6ce063fcf3d0cc555a16a8c05ebaab11f5607/coverage-7.10.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5c9e75dfdc0167d5675e9804f04a56b2cf47fb83a524654297000b578b8adcb7", size = 247090, upload-time = "2025-08-17T00:24:43.193Z" },
+    { url = "https://files.pythonhosted.org/packages/62/43/2ce5ab8a728b8e25ced077111581290ffaef9efaf860a28e25435ab925cf/coverage-7.10.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c751261bfe6481caba15ec005a194cb60aad06f29235a74c24f18546d8377df0", size = 247732, upload-time = "2025-08-17T00:24:44.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f3/706c4a24f42c1c5f3a2ca56637ab1270f84d9e75355160dc34d5e39bb5b7/coverage-7.10.4-cp311-cp311-win32.whl", hash = "sha256:051c7c9e765f003c2ff6e8c81ccea28a70fb5b0142671e4e3ede7cebd45c80af", size = 218961, upload-time = "2025-08-17T00:24:46.241Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/aa/6b9ea06e0290bf1cf2a2765bba89d561c5c563b4e9db8298bf83699c8b67/coverage-7.10.4-cp311-cp311-win_amd64.whl", hash = "sha256:1a647b152f10be08fb771ae4a1421dbff66141e3d8ab27d543b5eb9ea5af8e52", size = 219851, upload-time = "2025-08-17T00:24:48.795Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/be/f0dc9ad50ee183369e643cd7ed8f2ef5c491bc20b4c3387cbed97dd6e0d1/coverage-7.10.4-cp311-cp311-win_arm64.whl", hash = "sha256:b09b9e4e1de0d406ca9f19a371c2beefe3193b542f64a6dd40cfcf435b7d6aa0", size = 218530, upload-time = "2025-08-17T00:24:50.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/781c9e4dd57cabda2a28e2ce5b00b6be416015265851060945a5ed4bd85e/coverage-7.10.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a1f0264abcabd4853d4cb9b3d164adbf1565da7dab1da1669e93f3ea60162d79", size = 216706, upload-time = "2025-08-17T00:24:51.528Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8c/51255202ca03d2e7b664770289f80db6f47b05138e06cce112b3957d5dfd/coverage-7.10.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:536cbe6b118a4df231b11af3e0f974a72a095182ff8ec5f4868c931e8043ef3e", size = 216939, upload-time = "2025-08-17T00:24:53.171Z" },
+    { url = "https://files.pythonhosted.org/packages/06/7f/df11131483698660f94d3c847dc76461369782d7a7644fcd72ac90da8fd0/coverage-7.10.4-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9a4c0d84134797b7bf3f080599d0cd501471f6c98b715405166860d79cfaa97e", size = 248429, upload-time = "2025-08-17T00:24:54.934Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fa/13ac5eda7300e160bf98f082e75f5c5b4189bf3a883dd1ee42dbedfdc617/coverage-7.10.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7c155fc0f9cee8c9803ea0ad153ab6a3b956baa5d4cd993405dc0b45b2a0b9e0", size = 251178, upload-time = "2025-08-17T00:24:56.353Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/f63b56a58ad0bec68a840e7be6b7ed9d6f6288d790760647bb88f5fea41e/coverage-7.10.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a5f2ab6e451d4b07855d8bcf063adf11e199bff421a4ba57f5bb95b7444ca62", size = 252313, upload-time = "2025-08-17T00:24:57.692Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b6/79338f1ea27b01266f845afb4485976211264ab92407d1c307babe3592a7/coverage-7.10.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:685b67d99b945b0c221be0780c336b303a7753b3e0ec0d618c795aada25d5e7a", size = 250230, upload-time = "2025-08-17T00:24:59.293Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/93/3b24f1da3e0286a4dc5832427e1d448d5296f8287464b1ff4a222abeeeb5/coverage-7.10.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0c079027e50c2ae44da51c2e294596cbc9dbb58f7ca45b30651c7e411060fc23", size = 248351, upload-time = "2025-08-17T00:25:00.676Z" },
+    { url = "https://files.pythonhosted.org/packages/de/5f/d59412f869e49dcc5b89398ef3146c8bfaec870b179cc344d27932e0554b/coverage-7.10.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3749aa72b93ce516f77cf5034d8e3c0dfd45c6e8a163a602ede2dc5f9a0bb927", size = 249788, upload-time = "2025-08-17T00:25:02.354Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/52/04a3b733f40a0cc7c4a5b9b010844111dbf906df3e868b13e1ce7b39ac31/coverage-7.10.4-cp312-cp312-win32.whl", hash = "sha256:fecb97b3a52fa9bcd5a7375e72fae209088faf671d39fae67261f37772d5559a", size = 219131, upload-time = "2025-08-17T00:25:03.79Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dd/12909fc0b83888197b3ec43a4ac7753589591c08d00d9deda4158df2734e/coverage-7.10.4-cp312-cp312-win_amd64.whl", hash = "sha256:26de58f355626628a21fe6a70e1e1fad95702dafebfb0685280962ae1449f17b", size = 219939, upload-time = "2025-08-17T00:25:05.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c7/058bb3220fdd6821bada9685eadac2940429ab3c97025ce53549ff423cc1/coverage-7.10.4-cp312-cp312-win_arm64.whl", hash = "sha256:67e8885408f8325198862bc487038a4980c9277d753cb8812510927f2176437a", size = 218572, upload-time = "2025-08-17T00:25:06.897Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b0/4a3662de81f2ed792a4e425d59c4ae50d8dd1d844de252838c200beed65a/coverage-7.10.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b8e1d2015d5dfdbf964ecef12944c0c8c55b885bb5c0467ae8ef55e0e151233", size = 216735, upload-time = "2025-08-17T00:25:08.617Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e8/e2dcffea01921bfffc6170fb4406cffb763a3b43a047bbd7923566708193/coverage-7.10.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:25735c299439018d66eb2dccf54f625aceb78645687a05f9f848f6e6c751e169", size = 216982, upload-time = "2025-08-17T00:25:10.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/59/cc89bb6ac869704d2781c2f5f7957d07097c77da0e8fdd4fd50dbf2ac9c0/coverage-7.10.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:715c06cb5eceac4d9b7cdf783ce04aa495f6aff657543fea75c30215b28ddb74", size = 247981, upload-time = "2025-08-17T00:25:11.854Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/23/3da089aa177ceaf0d3f96754ebc1318597822e6387560914cc480086e730/coverage-7.10.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e017ac69fac9aacd7df6dc464c05833e834dc5b00c914d7af9a5249fcccf07ef", size = 250584, upload-time = "2025-08-17T00:25:13.483Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/82/e8693c368535b4e5fad05252a366a1794d481c79ae0333ed943472fd778d/coverage-7.10.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bad180cc40b3fccb0f0e8c702d781492654ac2580d468e3ffc8065e38c6c2408", size = 251856, upload-time = "2025-08-17T00:25:15.27Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/8b9cb13292e602fa4135b10a26ac4ce169a7fc7c285ff08bedd42ff6acca/coverage-7.10.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:becbdcd14f685fada010a5f792bf0895675ecf7481304fe159f0cd3f289550bd", size = 250015, upload-time = "2025-08-17T00:25:16.759Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e7/e5903990ce089527cf1c4f88b702985bd65c61ac245923f1ff1257dbcc02/coverage-7.10.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0b485ca21e16a76f68060911f97ebbe3e0d891da1dbbce6af7ca1ab3f98b9097", size = 247908, upload-time = "2025-08-17T00:25:18.232Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c9/7d464f116df1df7fe340669af1ddbe1a371fc60f3082ff3dc837c4f1f2ab/coverage-7.10.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6c1d098ccfe8e1e0a1ed9a0249138899948afd2978cbf48eb1cc3fcd38469690", size = 249525, upload-time = "2025-08-17T00:25:20.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/722e0cdbf6c19e7235c2020837d4e00f3b07820fd012201a983238cc3a30/coverage-7.10.4-cp313-cp313-win32.whl", hash = "sha256:8630f8af2ca84b5c367c3df907b1706621abe06d6929f5045fd628968d421e6e", size = 219173, upload-time = "2025-08-17T00:25:21.56Z" },
+    { url = "https://files.pythonhosted.org/packages/97/7e/aa70366f8275955cd51fa1ed52a521c7fcebcc0fc279f53c8c1ee6006dfe/coverage-7.10.4-cp313-cp313-win_amd64.whl", hash = "sha256:f68835d31c421736be367d32f179e14ca932978293fe1b4c7a6a49b555dff5b2", size = 219969, upload-time = "2025-08-17T00:25:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/96/c39d92d5aad8fec28d4606556bfc92b6fee0ab51e4a548d9b49fb15a777c/coverage-7.10.4-cp313-cp313-win_arm64.whl", hash = "sha256:6eaa61ff6724ca7ebc5326d1fae062d85e19b38dd922d50903702e6078370ae7", size = 218601, upload-time = "2025-08-17T00:25:25.295Z" },
+    { url = "https://files.pythonhosted.org/packages/79/13/34d549a6177bd80fa5db758cb6fd3057b7ad9296d8707d4ab7f480b0135f/coverage-7.10.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:702978108876bfb3d997604930b05fe769462cc3000150b0e607b7b444f2fd84", size = 217445, upload-time = "2025-08-17T00:25:27.129Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c0/433da866359bf39bf595f46d134ff2d6b4293aeea7f3328b6898733b0633/coverage-7.10.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e8f978e8c5521d9c8f2086ac60d931d583fab0a16f382f6eb89453fe998e2484", size = 217676, upload-time = "2025-08-17T00:25:28.641Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d7/2b99aa8737f7801fd95222c79a4ebc8c5dd4460d4bed7ef26b17a60c8d74/coverage-7.10.4-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:df0ac2ccfd19351411c45e43ab60932b74472e4648b0a9edf6a3b58846e246a9", size = 259002, upload-time = "2025-08-17T00:25:30.065Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cf/86432b69d57debaef5abf19aae661ba8f4fcd2882fa762e14added4bd334/coverage-7.10.4-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:73a0d1aaaa3796179f336448e1576a3de6fc95ff4f07c2d7251d4caf5d18cf8d", size = 261178, upload-time = "2025-08-17T00:25:31.517Z" },
+    { url = "https://files.pythonhosted.org/packages/23/78/85176593f4aa6e869cbed7a8098da3448a50e3fac5cb2ecba57729a5220d/coverage-7.10.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:873da6d0ed6b3ffc0bc01f2c7e3ad7e2023751c0d8d86c26fe7322c314b031dc", size = 263402, upload-time = "2025-08-17T00:25:33.339Z" },
+    { url = "https://files.pythonhosted.org/packages/88/1d/57a27b6789b79abcac0cc5805b31320d7a97fa20f728a6a7c562db9a3733/coverage-7.10.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c6446c75b0e7dda5daa876a1c87b480b2b52affb972fedd6c22edf1aaf2e00ec", size = 260957, upload-time = "2025-08-17T00:25:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e5/3e5ddfd42835c6def6cd5b2bdb3348da2e34c08d9c1211e91a49e9fd709d/coverage-7.10.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:6e73933e296634e520390c44758d553d3b573b321608118363e52113790633b9", size = 258718, upload-time = "2025-08-17T00:25:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/0b/d364f0f7ef111615dc4e05a6ed02cac7b6f2ac169884aa57faeae9eb5fa0/coverage-7.10.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:52073d4b08d2cb571234c8a71eb32af3c6923149cf644a51d5957ac128cf6aa4", size = 259848, upload-time = "2025-08-17T00:25:37.754Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c6/bbea60a3b309621162e53faf7fac740daaf083048ea22077418e1ecaba3f/coverage-7.10.4-cp313-cp313t-win32.whl", hash = "sha256:e24afb178f21f9ceb1aefbc73eb524769aa9b504a42b26857243f881af56880c", size = 219833, upload-time = "2025-08-17T00:25:39.252Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a5/f9f080d49cfb117ddffe672f21eab41bd23a46179a907820743afac7c021/coverage-7.10.4-cp313-cp313t-win_amd64.whl", hash = "sha256:be04507ff1ad206f4be3d156a674e3fb84bbb751ea1b23b142979ac9eebaa15f", size = 220897, upload-time = "2025-08-17T00:25:40.772Z" },
+    { url = "https://files.pythonhosted.org/packages/46/89/49a3fc784fa73d707f603e586d84a18c2e7796707044e9d73d13260930b7/coverage-7.10.4-cp313-cp313t-win_arm64.whl", hash = "sha256:f3e3ff3f69d02b5dad67a6eac68cc9c71ae343b6328aae96e914f9f2f23a22e2", size = 219160, upload-time = "2025-08-17T00:25:42.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/22/525f84b4cbcff66024d29f6909d7ecde97223f998116d3677cfba0d115b5/coverage-7.10.4-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a59fe0af7dd7211ba595cf7e2867458381f7e5d7b4cffe46274e0b2f5b9f4eb4", size = 216717, upload-time = "2025-08-17T00:25:43.875Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/58/213577f77efe44333a416d4bcb251471e7f64b19b5886bb515561b5ce389/coverage-7.10.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3a6c35c5b70f569ee38dc3350cd14fdd0347a8b389a18bb37538cc43e6f730e6", size = 216994, upload-time = "2025-08-17T00:25:45.405Z" },
+    { url = "https://files.pythonhosted.org/packages/17/85/34ac02d0985a09472f41b609a1d7babc32df87c726c7612dc93d30679b5a/coverage-7.10.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:acb7baf49f513554c4af6ef8e2bd6e8ac74e6ea0c7386df8b3eb586d82ccccc4", size = 248038, upload-time = "2025-08-17T00:25:46.981Z" },
+    { url = "https://files.pythonhosted.org/packages/47/4f/2140305ec93642fdaf988f139813629cbb6d8efa661b30a04b6f7c67c31e/coverage-7.10.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a89afecec1ed12ac13ed203238b560cbfad3522bae37d91c102e690b8b1dc46c", size = 250575, upload-time = "2025-08-17T00:25:48.613Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b5/41b5784180b82a083c76aeba8f2c72ea1cb789e5382157b7dc852832aea2/coverage-7.10.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:480442727f464407d8ade6e677b7f21f3b96a9838ab541b9a28ce9e44123c14e", size = 251927, upload-time = "2025-08-17T00:25:50.881Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ca/c1dd063e50b71f5aea2ebb27a1c404e7b5ecf5714c8b5301f20e4e8831ac/coverage-7.10.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a89bf193707f4a17f1ed461504031074d87f035153239f16ce86dfb8f8c7ac76", size = 249930, upload-time = "2025-08-17T00:25:52.422Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/66/d8907408612ffee100d731798e6090aedb3ba766ecf929df296c1a7ee4fb/coverage-7.10.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:3ddd912c2fc440f0fb3229e764feec85669d5d80a988ff1b336a27d73f63c818", size = 247862, upload-time = "2025-08-17T00:25:54.316Z" },
+    { url = "https://files.pythonhosted.org/packages/29/db/53cd8ec8b1c9c52d8e22a25434785bfc2d1e70c0cfb4d278a1326c87f741/coverage-7.10.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a538944ee3a42265e61c7298aeba9ea43f31c01271cf028f437a7b4075592cf", size = 249360, upload-time = "2025-08-17T00:25:55.833Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/75/5ec0a28ae4a0804124ea5a5becd2b0fa3adf30967ac656711fb5cdf67c60/coverage-7.10.4-cp314-cp314-win32.whl", hash = "sha256:fd2e6002be1c62476eb862b8514b1ba7e7684c50165f2a8d389e77da6c9a2ebd", size = 219449, upload-time = "2025-08-17T00:25:57.984Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ab/66e2ee085ec60672bf5250f11101ad8143b81f24989e8c0e575d16bb1e53/coverage-7.10.4-cp314-cp314-win_amd64.whl", hash = "sha256:ec113277f2b5cf188d95fb66a65c7431f2b9192ee7e6ec9b72b30bbfb53c244a", size = 220246, upload-time = "2025-08-17T00:25:59.868Z" },
+    { url = "https://files.pythonhosted.org/packages/37/3b/00b448d385f149143190846217797d730b973c3c0ec2045a7e0f5db3a7d0/coverage-7.10.4-cp314-cp314-win_arm64.whl", hash = "sha256:9744954bfd387796c6a091b50d55ca7cac3d08767795b5eec69ad0f7dbf12d38", size = 218825, upload-time = "2025-08-17T00:26:01.44Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/2e/55e20d3d1ce00b513efb6fd35f13899e1c6d4f76c6cbcc9851c7227cd469/coverage-7.10.4-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:5af4829904dda6aabb54a23879f0f4412094ba9ef153aaa464e3c1b1c9bc98e6", size = 217462, upload-time = "2025-08-17T00:26:03.014Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b3/aab1260df5876f5921e2c57519e73a6f6eeacc0ae451e109d44ee747563e/coverage-7.10.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7bba5ed85e034831fac761ae506c0644d24fd5594727e174b5a73aff343a7508", size = 217675, upload-time = "2025-08-17T00:26:04.606Z" },
+    { url = "https://files.pythonhosted.org/packages/67/23/1cfe2aa50c7026180989f0bfc242168ac7c8399ccc66eb816b171e0ab05e/coverage-7.10.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d57d555b0719834b55ad35045de6cc80fc2b28e05adb6b03c98479f9553b387f", size = 259176, upload-time = "2025-08-17T00:26:06.159Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/72/5882b6aeed3f9de7fc4049874fd7d24213bf1d06882f5c754c8a682606ec/coverage-7.10.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ba62c51a72048bb1ea72db265e6bd8beaabf9809cd2125bbb5306c6ce105f214", size = 261341, upload-time = "2025-08-17T00:26:08.137Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/70/a0c76e3087596ae155f8e71a49c2c534c58b92aeacaf4d9d0cbbf2dde53b/coverage-7.10.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0acf0c62a6095f07e9db4ec365cc58c0ef5babb757e54745a1aa2ea2a2564af1", size = 263600, upload-time = "2025-08-17T00:26:11.045Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/5f/27e4cd4505b9a3c05257fb7fc509acbc778c830c450cb4ace00bf2b7bda7/coverage-7.10.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1033bf0f763f5cf49ffe6594314b11027dcc1073ac590b415ea93463466deec", size = 261036, upload-time = "2025-08-17T00:26:12.693Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d6/cf2ae3a7f90ab226ea765a104c4e76c5126f73c93a92eaea41e1dc6a1892/coverage-7.10.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:92c29eff894832b6a40da1789b1f252305af921750b03ee4535919db9179453d", size = 258794, upload-time = "2025-08-17T00:26:14.261Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/39f222eab0d78aa2001cdb7852aa1140bba632db23a5cfd832218b496d6c/coverage-7.10.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:822c4c830989c2093527e92acd97be4638a44eb042b1bdc0e7a278d84a070bd3", size = 259946, upload-time = "2025-08-17T00:26:15.899Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b2/49d82acefe2fe7c777436a3097f928c7242a842538b190f66aac01f29321/coverage-7.10.4-cp314-cp314t-win32.whl", hash = "sha256:e694d855dac2e7cf194ba33653e4ba7aad7267a802a7b3fc4347d0517d5d65cd", size = 220226, upload-time = "2025-08-17T00:26:17.566Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b0/afb942b6b2fc30bdbc7b05b087beae11c2b0daaa08e160586cf012b6ad70/coverage-7.10.4-cp314-cp314t-win_amd64.whl", hash = "sha256:efcc54b38ef7d5bfa98050f220b415bc5bb3d432bd6350a861cf6da0ede2cdcd", size = 221346, upload-time = "2025-08-17T00:26:19.311Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/e0531c9d1525cb6eac5b5733c76f27f3053ee92665f83f8899516fea6e76/coverage-7.10.4-cp314-cp314t-win_arm64.whl", hash = "sha256:6f3a3496c0fa26bfac4ebc458747b778cff201c8ae94fa05e1391bab0dbc473c", size = 219368, upload-time = "2025-08-17T00:26:21.011Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/78/983efd23200921d9edb6bd40512e1aa04af553d7d5a171e50f9b2b45d109/coverage-7.10.4-py3-none-any.whl", hash = "sha256:065d75447228d05121e5c938ca8f0e91eed60a1eb2d1258d42d5084fecfc3302", size = 208365, upload-time = "2025-08-17T00:26:41.479Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
 name = "crudadmin"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -392,9 +472,11 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "coverage", extra = ["toml"] },
     { name = "faker" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
     { name = "types-redis" },
@@ -412,6 +494,7 @@ requires-dist = [
     { name = "arq", specifier = ">=0.25.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "bcrypt", specifier = ">=4.1.1" },
+    { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.3.2" },
     { name = "crudadmin", specifier = ">=0.4.2" },
     { name = "faker", marker = "extra == 'dev'", specifier = ">=26.0.0" },
     { name = "fastapi", specifier = ">=0.109.1" },
@@ -426,6 +509,7 @@ requires-dist = [
     { name = "pydantic", extras = ["email"], specifier = ">=2.6.1" },
     { name = "pydantic-settings", specifier = ">=2.0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.2" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-jose", specifier = ">=3.3.0" },
@@ -1001,6 +1085,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "6.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
+]
+
+[[package]]
 name = "pytest-mock"
 version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1176,6 +1274,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/cb/244daf0d7be4508099ad5bca3cdfe8b8b5538acd719c5f397f614e569fff/starlette-0.40.0.tar.gz", hash = "sha256:1a3139688fb298ce5e2d661d37046a66ad996ce94be4d4983be019a23a04ea35", size = 2573611, upload-time = "2024-10-15T06:52:34.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/0f/64baf7a06492e8c12f5c4b49db286787a7255195df496fc21f5fd9eecffa/starlette-0.40.0-py3-none-any.whl", hash = "sha256:c494a22fae73805376ea6bf88439783ecfba9aac88a43911b48c653437e784c4", size = 73303, upload-time = "2024-10-15T06:52:32.486Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload-time = "2024-11-27T22:38:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload-time = "2024-11-27T22:38:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload-time = "2024-11-27T22:38:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload-time = "2024-11-27T22:38:11.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload-time = "2024-11-27T22:38:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload-time = "2024-11-27T22:38:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload-time = "2024-11-27T22:38:15.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload-time = "2024-11-27T22:38:17.645Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload-time = "2024-11-27T22:38:19.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload-time = "2024-11-27T22:38:20.064Z" },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708, upload-time = "2024-11-27T22:38:21.659Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582, upload-time = "2024-11-27T22:38:22.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543, upload-time = "2024-11-27T22:38:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691, upload-time = "2024-11-27T22:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170, upload-time = "2024-11-27T22:38:27.921Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530, upload-time = "2024-11-27T22:38:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666, upload-time = "2024-11-27T22:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954, upload-time = "2024-11-27T22:38:31.702Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Complete implementation of trigger management API endpoints with type-specific handling for email and webhook triggers.

Closes Linear issue ENG-30

## API Endpoints Implemented

### Base Trigger Management
- ✅ `GET /triggers` - List triggers with filtering and pagination
- ✅ `GET /triggers/{id}` - Get single trigger  
- ✅ `DELETE /triggers/{id}` - Delete trigger (soft/hard)
- ✅ `PUT /triggers/{id}/enable` - Enable trigger
- ✅ `PUT /triggers/{id}/disable` - Disable trigger

### Email Trigger Endpoints
- ✅ `POST /triggers/email` - Create email trigger with validation
- ✅ `PUT /triggers/email/{id}` - Update email trigger
- ✅ `POST /triggers/email/{id}/test` - Test email trigger (rate limited)

### Webhook Trigger Endpoints  
- ✅ `POST /triggers/webhook` - Create webhook trigger with validation
- ✅ `PUT /triggers/webhook/{id}` - Update webhook trigger
- ✅ `POST /triggers/webhook/{id}/test` - Test webhook trigger (rate limited)

### Additional Endpoints
- ✅ `POST /triggers/{id}/validate` - Validate trigger configuration

## Implementation Details

### Architecture
- Type-specific handling for email and webhook triggers
- Redis write-through caching for performance (matching monitor pattern)
- Multi-tenant isolation throughout all operations
- Rate limiting on test endpoints to prevent abuse
- Constants pattern for state updates (ENABLE_TRIGGER_UPDATE, DISABLE_TRIGGER_UPDATE)

### Code Quality
- Follows same patterns as ENG-29 monitors implementation
- Comprehensive error handling with custom exceptions
- Full async/await implementation
- Type hints throughout (mypy strict mode compatible)

## Testing & Quality

- **29 comprehensive tests** covering all endpoints and edge cases
- **72.48% code coverage** for trigger module
- **All ruff checks pass** - code follows style guidelines
- **All mypy checks pass** - proper type safety
- **Function renaming** - Renamed test functions to avoid pytest conflicts

## Additional Improvements

- **Added coverage.py** for test coverage reporting
- **Created Makefile** with convenient development commands
- **Configured coverage** in pyproject.toml and .coveragerc

## Test Plan
```bash
# Run all trigger tests
make test-triggers

# Check coverage
make coverage-triggers

# Run linting
make lint

# Run type checking
make mypy
```

## Files Changed
- `src/app/api/v1/triggers.py` - Main API endpoints
- `tests/api/v1/test_triggers.py` - Comprehensive test suite
- `src/app/services/trigger_service.py` - Added get_multi method
- `src/app/api/v1/__init__.py` - Registered triggers router
- `pyproject.toml` - Added coverage dependencies
- `.coveragerc` - Coverage configuration
- `Makefile` - Development commands

🤖 Generated with [Claude Code](https://claude.ai/code)