### PR TITLE
fix: Remove redundant /admin prefix from tenant router

### DIFF
--- a/src/app/api/admin/tenants.py
+++ b/src/app/api/admin/tenants.py
@@ -35,7 +35,7 @@ from ...services.tenant_service import tenant_service
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/admin/tenants", tags=["admin-tenants"])
+router = APIRouter(prefix="/tenants", tags=["admin-tenants"])
 
 # Constants for tenant state updates
 SUSPEND_TENANT_UPDATE = TenantUpdate(status="suspended", name=None, slug=None)


### PR DESCRIPTION
## Summary
- Fixed duplicate `/admin/admin/` pattern in tenant API routes
- Changed tenant router prefix from `/admin/tenants` to `/tenants`

## Problem
The admin tenant routes were appearing as `/api/admin/admin/tenants` instead of `/api/admin/tenants` due to redundant prefix nesting.

## Solution
Updated the tenant router prefix in `src/app/api/admin/tenants.py` from `/admin/tenants` to `/tenants`, which correctly combines with the parent admin router's `/admin` prefix.

## Test plan
- [x] Verified routes now appear as `/api/admin/tenants` instead of `/api/admin/admin/tenants`
- [x] Checked other admin routers (networks, filter_scripts) already had correct prefixes

🤖 Generated with [Claude Code](https://claude.ai/code)